### PR TITLE
Make umask() always succeed and return 0 on Win32.

### DIFF
--- a/src/FileUtilUMASK.ml
+++ b/src/FileUtilUMASK.ml
@@ -38,6 +38,7 @@ let umask
   in
   let complement i = 0o0777 land (lnot i) in
   let try_umask i =
+    if Sys.os_type = "Win32" then 0 else
     try
       Unix.umask i
     with e ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -1457,7 +1457,7 @@ let test_fileutil =
 
 
 let () =
-  let _i: int = Unix.umask test_umask in
+  let _i: int = if Sys.os_type = "Win32" then 0 else Unix.umask test_umask in
   run_test_tt_main
     ("ocaml-fileutils" >:::
      [


### PR DESCRIPTION
Reliance on umask availability made FileUtil.mkdir completely impossible to use on win32.
Since there's no concept of umask in win32 at all, I think returning 0 is sort of sensible.

Now that there's opam-cross-windows and a working opam/cygwin installer, I think it's important to make the lib cross-platform again.
I've been playing with cross-building my programs for win32 with just OCAMLFIND_TOOLCHAIN=windows and testing them in Wine all without actually touching Windows, it will be cool if we can make OCaml suitable for writing apps that just work on all major OSes.