### PR TITLE
Add current and parent checks to Win32Path.

### DIFF
--- a/src/Win32Path.ml
+++ b/src/Win32Path.ml
@@ -65,6 +65,21 @@ let dir_reader str =
   with Not_found ->
     fn_part_split str
 
+let fast_is_current fn =
+  if String.length fn = 0 || fn = "." then
+    true
+  else if fn.[0] <> '.' then
+    false
+  else
+    raise CannotHandleFast
+
+let fast_is_parent fn =
+  if fn = ".." then
+    true
+  else if String.length fn < 2 || fn.[0] <> '.' || fn.[1] <> '.' then
+    false
+  else
+    raise CannotHandleFast
 
 let path_writer lst = String.concat ";" lst
 


### PR DESCRIPTION
Lack of those functions is a serious compatibility problem since it made `FileUtil.mkdir ~parent:true` unusuable. Since `mkdir_simple` looks up the parent for each dir, in 0.5.3, trying to do `FileUtil.mkdir ~parent:true "foo/bar"` when `foo` doesn't exist yet always results in `EmptyFilename` exception.

It creates other inconsistencies too, such as `FileUtil.test FileUtil.Exists ""` being true on UNIX but false on Windows.

Some tests related to `mkdir` still fail on Windows, but there are a number of tests that run even though they shouldn't and try to test umask and chmod there. I'll need to look into it.