### PR TITLE
Skip tests that require POSIX semantics on Win32

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -1162,6 +1162,7 @@ let test_fileutil =
 
     "Cp preserve" >::
     (fun test_ctxt ->
+       let () = skip_if (Sys.os_type = "Win32") "Directory atime/mtime modification is broken on Windows." in
        let tmp_dir = bracket_tmpdir test_ctxt in
        let dir1 = make_filename [tmp_dir; "dir1"] in
        let fn1 = make_filename [dir1; "fn1.txt"] in


### PR DESCRIPTION
I hope this is the last bit required to declare Win32 supported again and file pull requests against opam-cross-windows and opam-repository-mingw.

The first commit is straightforward, just don't test things on Win32 that Win32 doesn't have, like umask and UNIX file permissions.

With the `Cp preserve` test, the rabbit hole goes much deeper. As of the latest release, `Unix.utimes` doesn't work for directories on Win32 because its call to `CreateFile` is missing the incantation required to make it work for directories. With default flags, that function fails with an `INVALID_HANDLE` error if the file is a directory, and the flag required to make it work is called `FILE_FLAG_BACKUP_SEMANTICS`. For some reason.
I've filed a pull request (https://github.com/ocaml/ocaml/pull/8796), but until it's merged, there's nothing to be done about it, short of implementing a custom `utimes` in fileutils, and time-preserving copying is hardly common enough to warrant it.
I've made it a separate commit to make it easy to revert when the fix is available.


