### PR TITLE
Fix the docs for the argument order of FilePath.is_subdir

### DIFF
--- a/src/lib/fileutils/FilePath.mli
+++ b/src/lib/fileutils/FilePath.mli
@@ -65,10 +65,10 @@ exception InvalidFilename of filename
 
 (** {2 Ordering} *)
 
-(** [is_subdir fl1 fl2] Is [fl2] a sub directory of [fl1] *)
+(** [is_subdir child parent] Is [child] really a sub directory of [parent] *)
 val is_subdir: filename -> filename -> bool
 
-(** [is_updir fl1 fl2] Is [fl1] a sub directory of [fl2] *)
+(** [is_updir parent child] Is [parent] really a parent directory of [child] *)
 val is_updir: filename -> filename -> bool
 
 (** [compare fl1 fl2] Give an order between the two filename. The


### PR DESCRIPTION
It looks like the behaviour of `FilePath.is_subdir` is the opposite of what the [docs](https://docs.ocaml.pro/html/LIBRARY.fileutils@fileutils.0.6.3/FilePath/index.html#val-is_subdir) say.

```
utop # #require "fileutils";;

utop # FilePath.is_subdir "foo" "foo/bar" ;;
- : bool = false

utop # FilePath.is_subdir "foo/bar" "foo" ;;
- : bool = true
```

That causes me quite a bit of confusion during late night debugging (https://github.com/dmbaturin/soupault/issues/35).