### PR TITLE
Remove dependency on `base-bytes`

### DIFF
--- a/fileutils.opam
+++ b/fileutils.opam
@@ -15,7 +15,6 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "base-unix"
-  "base-bytes"
   "stdlib-shims"
   "dune" {>= "1.11.0"}
   "ounit" {with-test & >= "2.0.0"}

--- a/src/lib/fileutils/dune
+++ b/src/lib/fileutils/dune
@@ -30,4 +30,4 @@
     fileUtilWHICH
     unixPath
     win32Path)
-  (libraries unix bytes stdlib-shims))
+  (libraries unix stdlib-shims))


### PR DESCRIPTION
Bytes has been part of the compiler since 4.02, which is also the minimum required version that dune needs.

This also removes a transitive dependency on `ocamlfind`, allowing a smaller dependency cone.