### PR TITLE
Silence exceptions raised when closing after an exception in FileUtilCP

### DIFF
--- a/fileutils.opam
+++ b/fileutils.opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.05"}
   "base-unix"
   "stdlib-shims"
   "seq"


### PR DESCRIPTION
We're seeing reports of an error with a backtrace that cannot be used because a subsequent `Unix.close` erases the original exception. See: https://github.com/savonet/liquidsoap/issues/3732

This PR makes the close silent and preserves the original backtrace when re-raising the exception.