### PR TITLE
Make cmp return None for identical files

### DIFF
--- a/src/lib/fileutils/FileUtil.mli
+++ b/src/lib/fileutils/FileUtil.mli
@@ -498,8 +498,8 @@ val which:
 
 (** [cmp skip1 fln1 skip2 fln2] Compare files [fln1] and [fln2] starting at pos
     [skip1] [skip2] and returning the first octect where a difference occurs.
-    Returns [Some -1] if one of the file is not readable or if it is not a
-    file.
+    Returns [Some -1] if one of the files is not readable or if it is not a
+    file.  Returns [None] if given two identical files.
     See {{:http://pubs.opengroup.org/onlinepubs/007904875/utilities/cmp.html}POSIX documentation}.
   *)
 val cmp:

--- a/src/lib/fileutils/FileUtilCMP.ml
+++ b/src/lib/fileutils/FileUtilCMP.ml
@@ -48,11 +48,14 @@ let cmp ?(skip1 = 0) fln1 ?(skip2 = 0) fln2 =
     let rec loop count s1 s2 =
       match s1, s2 with
       | Seq.Cons (v1, s1), Seq.Cons (v2, s2) when v1 = v2 -> loop (count + 1) (s1 ()) (s2 ())
+      | Seq.Nil, Seq.Nil -> (-1)
       | _ -> count
     in
     let count = loop 0 (stream1 ()) (stream2 ()) in
     clean_fd ();
-    Some count
+    match count with
+    | (-1) -> None
+    | x -> Some x
   end else
     Some (-1)
 


### PR DESCRIPTION
Fixes https://github.com/gildor478/ocaml-fileutils/issues/57.  Given two distinct files with identical contents, the `cmp` function evalues to `Some x`, where `x` is the size of each file, instead of evaluating to `None`.  This breaks the gettext tests, which expect `None` in that case.  (And, on a human note, `None` just makes more sense to me, as it means there are no differences.)