### PR TITLE
Add examples for Fileutils (OCaml Examples Project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ Documentation
 
 API documentation is
 [available online](https://gildor478.github.io/ocaml-fileutils).
+
+
+Examples
+--------
+
+See the directory `examples`. This is a separate dune workspace, so install
+Fileutils first. 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# fileutils
+
+This example is for the fileutils library
+
+https://opam.ocaml.org/packages/fileutils
+
+# Source file
+
+`bin/main.ml`
+
+# Building and running
+
+`dune exec bin/main.exe filepath`
+
+`dune exec bin/main.exe fileutil`
+
+# Cleaning up
+
+`dune clean`

--- a/examples/bin/dune
+++ b/examples/bin/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries fileutils))

--- a/examples/bin/main.ml
+++ b/examples/bin/main.ml
@@ -1,0 +1,75 @@
+(* Fileutils provides two modules:
+     - FilePath is used for platform-agnostic file path manipulation, providing
+       more functionality than the Standard Library Filename module
+     - FileUtil implements some of the POSIX file manipulation programs such
+       as cp and rm, but implemented in pure, portable OCaml.
+*)
+
+(* Some examples from the FilePath module for file path manipultation. *)
+let filepath () =
+  Printf.printf "Current dir %S\n"
+    FilePath.current_dir;
+  Printf.printf "Parent dir %S\n"
+    FilePath.parent_dir;
+  Printf.printf "Make a filename from parts: %S\n"
+    (FilePath.make_filename ["one"; "two"; "three"]);
+  Printf.printf "Simplify a filename: %S\n"
+    (FilePath.reduce (FilePath.make_filename [FilePath.current_dir; "one"]));
+  Printf.printf "Replace an extension: %S\n"
+    (FilePath.replace_extension "foo.jpg" "jpeg");
+  Printf.printf "Making a PATH string: %S\n"
+    (FilePath.string_of_path ["one"; FilePath.make_filename ["two"; "three"]]);
+  let structure = [FilePath.parent_dir; "one"; "two"; "three"] in
+    Printf.printf "Unix: %S\nWindows: %S\nCygwin: %S\nDefault: %S = FilePath.: %S\n"
+      (FilePath.UnixPath.make_filename structure)
+      (FilePath.Win32Path.make_filename structure)
+      (FilePath.CygwinPath.make_filename structure)
+      (FilePath.DefaultPath.make_filename structure)
+      (FilePath.make_filename structure)
+
+(* The main FileUtil module, for POSIX-style filesystem manipulation. *)
+let fileutil () =
+  (* Make a directory for our example. *)
+  begin try
+    FileUtil.mkdir ~parent:true (FilePath.make_filename ["mkdir"; "example"])
+  with
+    e -> Printf.printf "mkdir error: %S\n" (Printexc.to_string e); raise e
+  end;
+  (* Copy a couple of files into it with *)
+  begin try
+    FileUtil.cp
+      ["dune-workspace"; "dune-project"] 
+      (FilePath.make_filename ["mkdir"; "example"])
+  with
+    e -> Printf.printf "cp error: %S\n" (Printexc.to_string e); raise e
+  end;
+  (* List directory contents *)
+  begin try
+    List.iter
+      (fun x -> Printf.printf "%s\n" (FilePath.basename x))
+      (FileUtil.ls (FilePath.make_filename ["mkdir"; "example"]))
+  with
+    e -> Printf.printf "ls error: %S\n" (Printexc.to_string e); raise e
+  end;
+  (* Compare the two files *)
+  begin match
+    FileUtil.cmp
+      (FilePath.make_filename ["mkdir"; "example"; "dune-workspace"])
+      (FilePath.make_filename ["mkdir"; "example"; "dune-project"])
+  with
+    | None -> Printf.printf "No difference\n"
+    | Some -1 -> Printf.printf "Could not complete comparison operation\n"
+    | Some p -> Printf.printf "Difference at position %i\n" p
+  end;
+  (* Delete everything to clean up *)
+  begin try
+    FileUtil.rm ~recurse:true ["mkdir"]
+  with
+    e -> Printf.printf "rmdir error: %S\n" (Printexc.to_string e); raise e
+  end
+
+let () =
+  match Sys.argv with
+  | [|_; "filepath"|] -> filepath ()
+  | [|_; "fileutil"|] -> fileutil ()
+  | _ -> Printf.eprintf "fileutils example: unknown command line\n"

--- a/examples/dune-project
+++ b/examples/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(name fileutils_example)

--- a/examples/dune-workspace
+++ b/examples/dune-workspace
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(env (dev (flags :standard -warn-error -A)))


### PR DESCRIPTION
Hello!

This pull request adds some examples to Fileutils. This is part of a pilot programme funded by the OCaml Software Foundation.

Many OCaml libraries have no examples, or perfunctory examples only. This makes it difficult to get started with a library, particularly if it has an elaborate interface. A working example, no matter how small, can help a newcomer get started quickly. One day, it would be nice to have an example for every opam package.

For now, examples begin in the OCaml Nursery, here: https://github.com/johnwhitington/ocaml-nursery  (you can read in the README there about the principles behind these examples.) Then, if package authors agree, they are promoted to upstream source. The hope is that this will mean they are more likely to be kept up to date with the library.

The examples are included in a separate directory, within a separate Dune workspace. And so they are intended to be used after installation of the library.

As well as considering accepting this pull request, please give any comments you have on this programme.